### PR TITLE
remove BUILDPACK_URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,8 +6,5 @@
   "success_url": "/",
   "addons": [
       "heroku-postgresql"
-  ],
-  "env": {
-      "BUILDPACK_URL": "https://github.com/kr/heroku-buildpack-go"
-  }
+  ]
 }


### PR DESCRIPTION
This isn't required anymore because we officially support Go now: https://blog.heroku.com/archives/2015/7/7/go_support_now_official_on_heroku
